### PR TITLE
Change the handler to raise a 404 rather rc.NOT_FOUND

### DIFF
--- a/billy/web/api/handlers.py
+++ b/billy/web/api/handlers.py
@@ -5,7 +5,7 @@ import json
 import itertools
 from collections import defaultdict
 
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 
 from billy.core import db, feeds_db
 from billy.models import Bill
@@ -90,7 +90,7 @@ class BillyHandlerMetaClass(HandlerMetaClass):
                     return obj
 
                 if obj is None:
-                    return rc.NOT_FOUND
+                    raise Http404("No such entry")
 
                 return obj
 


### PR DESCRIPTION
 Some piston changes seem to have altered the behavior of how
 rc.NOT_FOUND behaves. This triggers an error from inside Piston::

    |   File "/projects/openstates/virt/src/billy/billy/web/api/handlers.py", line 91, in new_read
    |     return rc.NOT_FOUND
    |
    |   File "/projects/openstates/virt/src/django-piston/piston/utils.py", line 55, in __getattr__
    |     class HttpResponseWrapper(HttpResponse):
    |
    |   File "/projects/openstates/virt/src/django-piston/piston/utils.py", line 82, in HttpResponseWrapper
    |     content = property(HttpResponse._get_content, _set_content)
    |
    | AttributeError: type object 'HttpResponse' has no attribute '_get_content'

 (as seen in some API calls)

 I can't reproduce this locally, but I can see that I've not caused regressions
 here. Looking over the pison source, the Http404 control flow should avoid
 hitting this error.