### PR TITLE
Handle DC's Wards as if they were SLDLs/SLDUs

### DIFF
--- a/billy/web/api/handlers.py
+++ b/billy/web/api/handlers.py
@@ -405,7 +405,7 @@ class LegislatorGeoHandler(BillyHandler):
             # ocd-division/country:us/state:oh/cd:11
             _, localpart = ocdid.rsplit("/", 1)
             set_, series = localpart.split(":", 1)
-            if set_ not in ['sldl', 'sldu']:
+            if set_ not in ['sldl', 'sldu', 'ward']:
                 # Place, CD, County, ...
                 continue
 


### PR DESCRIPTION
This will allow `find_my_legislator` to properly identify the District's representatives.