### PR TITLE
changed django-piston to point to more recent fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django<1.7
 django-pjax
--e hg+https://bitbucket.org/jespern/django-piston#egg=django-piston
+-e git://github.com/marcio0/django-piston/#egg=django-piston
 boto
 icalendar
 lxml>=2.2


### PR DESCRIPTION
django-piston no longer being maintained, was incompatible with django1.6. This more recent fork causes error messages to be transmitted appropriately.