### PR TITLE
Allow retries when dumping JSON if the API is being persnickity

### DIFF
--- a/billy/bin/commands/dump.py
+++ b/billy/bin/commands/dump.py
@@ -250,7 +250,7 @@ class DumpJSON(BaseCommand):
                 upload(abbr, args.file, 'json')
 
     def dump(self, abbr, filename, validate, schema_dir):
-        scraper = scrapelib.Scraper(requests_per_minute=600)
+        scraper = scrapelib.Scraper(requests_per_minute=600, retry_attempts=3)
 
         zip = zipfile.ZipFile(filename, 'w', zipfile.ZIP_DEFLATED)
 


### PR DESCRIPTION
The JSON dumps have had issues with API non-responsiveness in the last few months; hopefully this'll mitigate that so we don't have to manually re-run the JSON dump job after failure.